### PR TITLE
fix `[ddu] highlight "" does not exist`

### DIFF
--- a/denops/@ddu-sources/dummy.ts
+++ b/denops/@ddu-sources/dummy.ts
@@ -23,12 +23,14 @@ export class Source extends BaseSource<Params> {
         controller.enqueue([{
           word,
           display: display !== "" ? display : undefined,
-          highlights: [{
-            name: "ddu-dummy",
-            hl_group: hlGroup,
-            col: 1,
-            width: byteLength(display || word),
-          }],
+          highlights: hlGroup !== ""
+            ? [{
+              name: "ddu-dummy",
+              hl_group: hlGroup,
+              col: 1,
+              width: byteLength(display || word),
+            }]
+            : undefined,
         }]);
 
         controller.close();


### PR DESCRIPTION
If I done't set `hlGroup`, the message like bellow be showed.

![image](https://github.com/user-attachments/assets/c103496f-b766-4a0b-8947-62c0ca78c4de)

So if `hlGroup` is setted `""` as default, I doesn't define highlight.
